### PR TITLE
[eloop.c]: Increase timeout of signal termination

### DIFF
--- a/src/utils/eloop.c
+++ b/src/utils/eloop.c
@@ -39,6 +39,10 @@
 #include <sys/event.h>
 #endif /* CONFIG_ELOOP_KQUEUE */
 
+#ifndef CONFIG_NATIVE_WINDOWS
+#define SIGNAL_TERMINATION_TIMEOUT 120
+#endif
+
 struct eloop_sock {
 	int sock;
 	void *eloop_data;
@@ -962,10 +966,10 @@ int eloop_replenish_timeout(unsigned int req_secs, unsigned int req_usecs,
 static void eloop_handle_alarm(int sig)
 {
 	wpa_printf(MSG_ERROR, "eloop: could not process SIGINT or SIGTERM in "
-		   "two seconds. Looks like there\n"
+		   "%d seconds. Looks like there\n"
 		   "is a bug that ends up in a busy loop that "
 		   "prevents clean shutdown.\n"
-		   "Killing program forcefully.\n");
+		   "Killing program forcefully.\n", SIGNAL_TERMINATION_TIMEOUT);
 	exit(1);
 }
 #endif /* CONFIG_NATIVE_WINDOWS */
@@ -981,7 +985,7 @@ static void eloop_handle_signal(int sig)
 		 * would not allow the program to be killed. */
 		eloop.pending_terminate = 1;
 		signal(SIGALRM, eloop_handle_alarm);
-		alarm(2);
+		alarm(SIGNAL_TERMINATION_TIMEOUT);
 	}
 #endif /* CONFIG_NATIVE_WINDOWS */
 


### PR DESCRIPTION
Increase the timeout of signal termination from 2 seconds to 120 seconds. Because the cleanup MACsec objs depends on the response from orchagent, but the orchagent cannot always handle all cleanup actions within 2 seconds. So increase this timeout to guarantee all MACsec objs can be cleanup successfully.
Signed-off-by: Ze Gan <ganze718@gmail.com>