### PR TITLE
[mka]: Remove MKA_VERSION check for MKA_XPN frame

### DIFF
--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -3423,8 +3423,8 @@ static int ieee802_1x_kay_decode_mkpdu(struct ieee802_1x_kay *kay,
 		if (body_type == MKA_ICV_INDICATOR)
 			return 0;
 
-		if (kay->mka_version == MKA_VERSION_1 && body_type == MKA_XPN) {
-			wpa_printf(MSG_DEBUG, "MKA_XPN (type 8) hasn't been supported in MKA VERSION 1");
+		if (body_type == MKA_XPN) {
+			wpa_printf(MSG_DEBUG, "MKA_XPN (type 8) hasn't been supported");
 			continue;
 		}
 


### PR DESCRIPTION
MKA_XPN tag may be in non-MKA_VERSION_1 frames, so remove the the MKA VERSION check to ignore the MKA_XPN frame

Signed-off-by: Ze Gan <ganze718@gmail.com>