### PR TITLE
Install libyang in azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,24 @@ jobs:
     inputs:
       source: specific
       project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        target/debs/buster/libyang-*.deb
+        target/debs/buster/libyang_*.deb
+    displayName: "Download libyang from amd64 common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang from common lib"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
       pipeline: 9
       artifact: sonic-swss-common
       runVersion: 'latestFromBranch'
@@ -84,6 +102,24 @@ jobs:
         swig3.0 \
         libpython2.7-dev
     displayName: "Install dependencies"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib.arm64
+      patterns: |
+        target/debs/buster/libyang-*.deb
+        target/debs/buster/libyang_*.deb
+    displayName: "Download libyang from arm64 common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
@@ -134,6 +170,24 @@ jobs:
         swig3.0 \
         libpython2.7-dev
     displayName: "Install dependencies"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib.armhf
+      patterns: |
+        target/debs/buster/libyang-*.deb
+        target/debs/buster/libyang_*.deb
+    displayName: "Download libyang from armhf common lib"
+  - script: |
+      set -ex
+      sudo dpkg -i $(find ./download -name *.deb)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -28,6 +28,8 @@ extraction:
       - "libzmq3-dev"
       - "libzmq5"
       - "libgmock-dev"
+      - "libyang"
+      - "libyang-dev"
     after_prepare:
     - "ls -l"
     - "git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common;\


### PR DESCRIPTION
#### Why I did it
sonic-swss-common lib will add depency to libyang soon, so need install libyang lib to prevent build and UT break.

#### How I did it
Modify azure pipeline to install libyang in azure pipeline steps.

#### How to verify it
Pass all UT.

#### Which release branch to backport (provide reason below if selected)

#### Description for the changelog
Modify azure pipeline to install libyang in azure pipeline steps.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

