### PR TITLE
[mka]: Fix re-establishment by reset MI

### DIFF
--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -2667,6 +2667,7 @@ static void ieee802_1x_participant_timer(void *eloop_ctx, void *timeout_ctx)
 	struct ieee802_1x_kay_peer *peer, *pre_peer;
 	time_t now = time(NULL);
 	bool lp_changed;
+	bool key_server_removed;
 	struct receive_sc *rxsc, *pre_rxsc;
 	struct transmit_sa *txsa, *pre_txsa;
 
@@ -2691,6 +2692,7 @@ static void ieee802_1x_participant_timer(void *eloop_ctx, void *timeout_ctx)
 	}
 
 	lp_changed = false;
+	key_server_removed = false;
 	dl_list_for_each_safe(peer, pre_peer, &participant->live_peers,
 			      struct ieee802_1x_kay_peer, list) {
 		if (now > peer->expire) {
@@ -2706,9 +2708,32 @@ static void ieee802_1x_participant_timer(void *eloop_ctx, void *timeout_ctx)
 						participant, rxsc);
 				}
 			}
+			key_server_removed |= peer->is_key_server;
 			dl_list_del(&peer->list);
 			os_free(peer);
 			lp_changed = true;
+		}
+	}
+
+	/**
+	 * Key server may be removed due to the ingress packets delay.
+	 * In this situation, the endpoint of key server may not be aware of
+	 * this participant who has removed the key server from the peer list.
+	 * Because the egress traffic is normal, the key server will not
+	 * remove this participant from the peer list of key server.
+	 * So in the next MKA message, the key server will not dispatch a
+	 * new SAK to this participant.
+	 * And this participant can not be aware that is a new round
+	 * of communication so it will not update its mi at re-adding
+	 * the key server to its peer list.
+	 * So we need to update mi to avoid the failure of the re-establishment
+	 * MKA session.
+	 */
+	if (key_server_removed) {
+		if (!reset_participant_mi(participant)) {
+			wpa_printf(MSG_WARNING, "KaY: Could not update mi");
+		} else {
+			wpa_printf(MSG_DEBUG, "KaY: Update mi");
 		}
 	}
 


### PR DESCRIPTION
Key server may be removed due to the ingress packets delay. In this situation, the endpoint of key server may not be aware of this participant who has removed the key server from the peer list. Because the egress traffic is normal, the key server will not remove this participant from the peer list of key server. So in the next MKA message, the key server will not dispatch a new SAK to this participant.
And this participant can not be aware that is a new round of communication so it will not update its mi at re-adding the key server to its peer list.
So we need to update mi to avoid the failure of the re-establishment MKA session.

The following is the issue situation log that failed to re-establish after a cleanup. It shows the wpa_supplicant continuously processes two ingress packets so that wpa_supplicant and server cannot be aware this communication session is a new round of negotiation.
```python
Apr 18 00:16:05.919878 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:05.919890 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:16:05.919989 DEBUG macsec0#wpa_supplicant[18]: Live Peer List parameter set
Apr 18 00:16:05.919998 DEBUG macsec0#wpa_supplicant[18]: #011Body Length: 16
Apr 18 00:16:05.920007 DEBUG macsec0#wpa_supplicant[18]: #011Member Id: 5c759b5f01be5bc0fae82b83  Message Number: 27
...
Apr 18 00:16:06.584718 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:06.584729 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:16:06.584899 DEBUG macsec0#wpa_supplicant[18]: KaY: Move potential peer to live peer
Apr 18 00:16:06.584899 DEBUG macsec0#wpa_supplicant[18]: #011MI: 7d22c8062bd410b73cef9df7  MN: 9  SCI: 94:8e:d3:1f:cd:98@1006
Apr 18 00:16:06.584916 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_create_receive_sc Ethernet0:948ed31fcd9803ee (conf_offset=0 validation=2)
```
But in the correct situation, the wpa_supplicant process the ingress and egress packets one by one. And the two ingress packets were processed with an expected interval( about 2 seconds). It provides an opportunity for both sides to be aware of this new round of negotiation.
```python
Apr 18 00:20:34.384385 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:20:34.384385 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:20:36.422618 DEBUG macsec0#wpa_supplicant[18]: KaY: Encode and send an MKPDU (ifname=Ethernet0)
Apr 18 00:20:36.422618 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=e0:69:ba:74:d0:1a Ethertype=0x888e
...
Apr 18 00:20:36.484053 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:20:36.484068 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:20:36.484282 DEBUG macsec0#wpa_supplicant[18]: KaY: Move potential peer to live peer
```

