### PR TITLE
[mka]: Fix unexpected cleanup

### DIFF
--- a/src/pae/ieee802_1x_kay.c
+++ b/src/pae/ieee802_1x_kay.c
@@ -1945,6 +1945,18 @@ ieee802_1x_mka_decode_dist_sak_body(
 	kay->rcvd_keys++;
 	participant->to_use_sak = true;
 
+	/**
+	 * Because the key server may not include dist sak and use sak in ONE packet,
+	 * Meanwhile, after dist sak, the current participant(Non-Key Server) will
+	 * install SC or SA(s) after decoding the dist sak which may take few seconds
+	 * in real physical platforms. Meanwhile, the peer expire time is always
+	 * initialized at adding the key server to peer list. The gap between adding
+	 * the key server to peer list and processing next use sak packet may exceed
+	 * the threshold of MKA_LIFE_TIME(6s). It will cause an unexpected cleanup
+	 * (delete SC and SA(s)). So, update the expire timeout at dist sak also.
+	 */
+	peer->expire = time(NULL) + MKA_LIFE_TIME / 1000;
+
 	return 0;
 }
 


### PR DESCRIPTION
Because the key server may not include dist sak and use sak in ONE packet, Meanwhile, after dist sak, the current participant(Non-Key Server) will install SC or SA(s) after decoding the dist sak which may take few seconds in real physical platforms. Meanwhile, the peer expire time is always initialized at adding the key server to peer list. The gap between adding the key server to peer list and processing next use sak packet may exceed the threshold of MKA_LIFE_TIME(6s). It will cause an unexpected cleanup (delete SC and SA(s)). So, update the expire timeout at dist sak also.

The following are debug logs from wpa_supplicant at the issue time slot.
```python

# The first point to initialize the expire time
Apr 18 00:15:58.283482 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:15:58.283533 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:15:58.283638 DEBUG macsec0#wpa_supplicant[18]: #011Actor's Message Number: 3
...
Apr 18 00:15:58.283690 DEBUG macsec0#wpa_supplicant[18]: KaY: i_in_peerlist=Yes is_in_live_peer=No
Apr 18 00:15:58.283690 DEBUG macsec0#wpa_supplicant[18]: KaY: Create receive SC: SCI 94:8e:d3:1f:cd:98@1006
Apr 18 00:15:58.283690 DEBUG macsec0#wpa_supplicant[18]: KaY: Move potential peer to live peer

# Received few packets from peer but not include SAK use section, so the expire time will not be updated
...
Apr 18 00:16:00.284311 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:00.284311 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
Apr 18 00:16:00.284311 DEBUG macsec0#wpa_supplicant[18]: KaY: Common EAPOL PDU structure: Protocol Version=3 Packet Type=5 Packet Body Length=80
...
Apr 18 00:16:00.284385 DEBUG macsec0#wpa_supplicant[18]: #011Actor's Message Number: 4
...
Apr 18 00:16:02.384778 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:02.384797 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:16:02.384884 DEBUG macsec0#wpa_supplicant[18]: #011Actor's Message Number: 5
...

# Create MACsec entries for the MKA establishment

Apr 18 00:16:02.883904 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:02.883911 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:16:02.883997 DEBUG macsec0#wpa_supplicant[18]: #011Actor's Message Number: 6
Apr 18 00:16:02.884119 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_set_current_cipher_suite GCM-AES-XPN-256(0080c20001000004)
Apr 18 00:16:02.884574 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_enable_protect_frames true
Apr 18 00:16:02.885152 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_enable_encrypt true
...
Apr 18 00:16:02.891858 DEBUG macsec0#wpa_supplicant[18]: KaY: Encode and send an MKPDU (ifname=Ethernet0)
Apr 18 00:16:02.891858 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=e0:69:ba:74:d0:1a Ethertype=0x888e
...
Apr 18 00:16:04.905191 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_get_transmit_next_pn SA Ethernet0:e069ba74d01a0001:0 PN 1
Apr 18 00:16:04.905214 DEBUG macsec0#wpa_supplicant[18]: MACsec SAK Use parameter set
...
Apr 18 00:16:04.905316 DEBUG macsec0#wpa_supplicant[18]: CP: CP entering state TRANSMIT
Apr 18 00:16:04.905316 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_enable_controlled_port true
Apr 18 00:16:04.905811 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_enable_transmit_sa Ethernet0:e069ba74d01a0001
...
Apr 18 00:16:04.906928 DEBUG macsec0#wpa_supplicant[18]: CP: CP entering state TRANSMITTING

# The issue point of unexpected Cleanup 
Apr 18 00:16:04.906928 DEBUG macsec0#wpa_supplicant[18]: KaY: Encode and send an MKPDU (ifname=Ethernet0)
Apr 18 00:16:04.906965 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=e0:69:ba:74:d0:1a Ethertype=0x888e
...
Apr 18 00:16:05.910442 DEBUG macsec0#wpa_supplicant[18]: KaY: Delete receive SC
Apr 18 00:16:05.910454 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_disable_receive_sa Ethernet0:948ed31fcd9803ee:0
Apr 18 00:16:05.910724 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_delete_receive_sa Ethernet0:948ed31fcd9803ee:0
Apr 18 00:16:05.911377 DEBUG macsec0#wpa_supplicant[18]: KaY: Delete receive SA(an: 0) of SC
Apr 18 00:16:05.911377 DEBUG macsec0#wpa_supplicant[18]: macsec_sonic(Ethernet0) : macsec_sonic_delete_receive_sc Ethernet0:948ed31fcd9803ee
...

# This packet was expected to be processed before 00:15:58 + 6s = 00:16:04, but due to some hardware calls which take more than 2 seconds, So the above-unexpected cleanup was triggered.
Apr 18 00:16:05.918521 DEBUG macsec0#wpa_supplicant[18]: KaY: Decode received MKPDU (ifname=Ethernet0)
Apr 18 00:16:05.918532 DEBUG macsec0#wpa_supplicant[18]: KaY: Ethernet header: DA=01:80:c2:00:00:03 SA=94:8e:d3:1f:cd:98 Ethertype=0x888e
...
Apr 18 00:16:05.918684 DEBUG macsec0#wpa_supplicant[18]: #011Actor's Message Number: 7
```