### PR TITLE
Fix Compile Error Issues with Debian Bookworm Build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,14 @@ include /usr/share/dpkg/default.mk
 
 # The build system doesn't use CPPFLAGS, pass them to CFLAGS/CXXFLAGS to
 # enable the missing (hardening) flags
-DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds)
+# Added no-deprecated-declarations use-after-free and no-discarded-qualifiers
+# to resolve the compile errors with bookworm. There are deprecated APIs with
+# openssl 3.0 which are used by wpa supplicant. We can remove those flags when
+# there are solutions ready.
+DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
+                                      -Wno-deprecated-declarations $(warning WARNING: Building with -Wno-deprecated-declarations) \
+									  -Wno-use-after-free $(warning WARNING: Building with -Wno-use-after-free)       \
+									  -Wno-discarded-qualifiers $(warning WARNING: Building with -Wno-discarded-qualifiers)
 DEB_CXXFLAGS_MAINT_APPEND = $(shell dpkg-buildflags --get CPPFLAGS)
 DEB_LDFLAGS_MAINT_APPEND  = -Wl,--as-needed
 export DEB_CFLAGS_MAINT_APPEND DEB_CXXFLAGS_MAINT_APPEND DEB_LDFLAGS_MAINT_APPEND

--- a/debian/rules
+++ b/debian/rules
@@ -13,8 +13,8 @@ include /usr/share/dpkg/default.mk
 # there are solutions ready.
 DEB_CFLAGS_MAINT_APPEND   = -MMD -Wall $(shell dpkg-buildflags --get CPPFLAGS) -Wno-error=array-bounds $(warning WARNING: Building with -Wno-error=array-bounds) \
                                       -Wno-deprecated-declarations $(warning WARNING: Building with -Wno-deprecated-declarations) \
-									  -Wno-use-after-free $(warning WARNING: Building with -Wno-use-after-free)       \
-									  -Wno-discarded-qualifiers $(warning WARNING: Building with -Wno-discarded-qualifiers)
+                                      -Wno-use-after-free $(warning WARNING: Building with -Wno-use-after-free)       \
+                                      -Wno-discarded-qualifiers $(warning WARNING: Building with -Wno-discarded-qualifiers)
 DEB_CXXFLAGS_MAINT_APPEND = $(shell dpkg-buildflags --get CPPFLAGS)
 DEB_LDFLAGS_MAINT_APPEND  = -Wl,--as-needed
 export DEB_CFLAGS_MAINT_APPEND DEB_CXXFLAGS_MAINT_APPEND DEB_LDFLAGS_MAINT_APPEND


### PR DESCRIPTION
**Why I did it**
When building debian package under debian bookworm. Following issues came out the build process.

1) Lots of APIs are deprecated form openssl 3.0. bookwork gcc has strict check to take deprecated warning as errors. Examples of warnings:
_../src/common/dpp_crypto.c:477:9: error: 'EVP_PKEY_set1_EC_KEY' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]_
There are more than 20 APIs has this issue.
2) bookworm gcc complains about possible pointer use after free. It's identified to be a false positive error as code seems to be OK on that area.
_In function 'wpa_bss_update',
inlined from 'wpa_bss_update_scan_res' at bss.c:824:9:
bss.c:714:25: error: pointer 'bss' may be used after 'realloc' [-Werror=use-after-free]_
3) Bookworm gcc complains about assignment discards 'const' qualifier from pointer target.
_../src/crypto/crypto_openssl.c: In function 'crypto_ec_key_parse_pub':
../src/crypto/crypto_openssl.c:2238:20: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
2238 | key->eckey = EVP_PKEY_get0_EC_KEY(key->pkey);_

**How I did it**
Current solution is to add build flags to ignore those warnings. We can remove those flags when there are solutions to above issues in the code.

**How to verify it**
Build wpa-supplicant under bookworm with openssl 3.0.11. You will see make fails with errors above. With the fix you will be able to build the debian package of wpasupplicant_2.9.0-14_amd64.deb for sonic for bookworm.