### PR TITLE
Fix a memory leak introduced by last commit for high level EVP API 

### DIFF
--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -1253,6 +1253,7 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 	ret = 0;
 fail:
 	EVP_MAC_CTX_free(ctx);
+	EVP_MAC_free(emac);
 	return ret;
 #else /* OpenSSL version >= 3.0 */
 	CMAC_CTX *ctx;


### PR DESCRIPTION
The last commit to use Openssl high level EVP API for CMAC has an issue where the EVP_MAC object created by EVP_MAC_fetch() is not freed. 

Added the EVP_MAC_free() to free the fetched object after use. 