### PR TITLE
test

### DIFF
--- a/debian/config/wpasupplicant/linux
+++ b/debian/config/wpasupplicant/linux
@@ -603,3 +603,6 @@ CONFIG_OWE=y
 # This requires CONFIG_IEEE80211W=y to be enabled, too. (see
 # wpa_supplicant/README-DPP for details)
 CONFIG_DPP=y
+
+# CONFIG_FIPS=y
+CONFIG_OPENSSL_CMAC=y

--- a/src/crypto/aes-omac1.c
+++ b/src/crypto/aes-omac1.c
@@ -43,6 +43,7 @@ static void gf_mulx(u8 *pad)
 int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 		     const u8 *addr[], const size_t *len, u8 *mac)
 {
+	wpa_printf(MSG_ERROR, "Self CMAC: omac1_aes_vector");
 	void *ctx;
 	u8 cbc[AES_BLOCK_SIZE], pad[AES_BLOCK_SIZE];
 	const u8 *pos, *end;

--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -1218,6 +1218,7 @@ int crypto_get_random(void *buf, size_t len)
 int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 		     const u8 *addr[], const size_t *len, u8 *mac)
 {
+	wpa_printf(MSG_ERROR, "Openssl  CMAC: omac1_aes_vector");
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 	EVP_MAC_CTX *ctx = NULL;
 	EVP_MAC *emac;


### PR DESCRIPTION
Default configuration 
```
root@vlab-01:/var/log# zcat syslog* | grep -i macsec | grep -i CMAC

gzip: syslog: not in gzip format

gzip: syslog.1: not in gzip format
Mar 19 12:21:10.560054 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:10.560054 vlab-01 ERR macsec#wpa_supplicant[41]: message repeated 3 times: [ Self CMAC: omac1_aes_vector]
Mar 19 12:21:10.723205 vlab-01 ERR macsec#wpa_supplicant[74]: Self CMAC: omac1_aes_vector
Mar 19 12:21:10.723205 vlab-01 ERR macsec#wpa_supplicant[74]: message repeated 3 times: [ Self CMAC: omac1_aes_vector]
Mar 19 12:21:11.073065 vlab-01 ERR macsec#wpa_supplicant[74]: Self CMAC: omac1_aes_vector
Mar 19 12:21:12.106165 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:16.638691 vlab-01 ERR macsec#wpa_supplicant[74]: message repeated 3 times: [ Self CMAC: omac1_aes_vector]
Mar 19 12:21:16.638691 vlab-01 ERR macsec#wpa_supplicant[74]: Self CMAC: omac1_aes_vector
Mar 19 12:21:30.051556 vlab-01 ERR macsec#wpa_supplicant[41]: message repeated 16 times: [ Self CMAC: omac1_aes_vector]
Mar 19 12:21:30.051556 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:31.734053 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:32.034145 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:33.738027 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:34.056153 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
Mar 19 12:21:36.078202 vlab-01 ERR macsec#wpa_supplicant[41]: message repeated 4 times: [ Self CMAC: omac1_aes_vector]
Mar 19 12:21:36.718788 vlab-01 ERR macsec#wpa_supplicant[41]: Self CMAC: omac1_aes_vector
```
CONFIG_OPENSSL_CMAC=y

```
root@vlab-01:/var/log# zcat syslog* | grep -i macsec | grep -i cmac

gzip: syslog: not in gzip format

gzip: syslog.1: not in gzip format
Mar 19 13:53:55.181969 vlab-01 ERR macsec#wpa_supplicant[40]: Openssl  CMAC: omac1_aes_vector
Mar 19 13:53:55.182152 vlab-01 ERR macsec#wpa_supplicant[40]: message repeated 3 times: [ Openssl  CMAC: omac1_aes_vector]
Mar 19 13:53:55.238930 vlab-01 ERR macsec#wpa_supplicant[40]: Openssl  CMAC: omac1_aes_vector
Mar 19 13:53:55.310716 vlab-01 ERR macsec#wpa_supplicant[73]: Openssl  CMAC: omac1_aes_vector
Mar 19 13:53:55.310716 vlab-01 ERR macsec#wpa_supplicant[73]: message repeated 3 times: [ Openssl  CMAC: omac1_aes_vector]
Mar 19 13:53:56.303398 vlab-01 ERR macsec#wpa_supplicant[73]: Openssl  CMAC: omac1_aes_vector
Mar 19 13:54:01.007559 vlab-01 ERR macsec#wpa_supplicant[40]: message repeated 3 times: [ Openssl  CMAC: omac1_aes_vector]
Mar 19 13:54:01.008592 vlab-01 ERR macsec#wpa_supplicant[40]: Openssl  CMAC: omac1_aes_vector
root@vlab-01:/var/log# exit

```