### PR TITLE
Make Openssl CMAC API (omac1_aes_vector) Availalable in Non FIPs Mode

### DIFF
--- a/hostapd/Makefile
+++ b/hostapd/Makefile
@@ -919,9 +919,11 @@ endif
 ifdef NEED_AES_ENCBLOCK
 AESOBJS += ../src/crypto/aes-encblock.o
 endif
+ifneq ($(CONFIG_TLS), openssl)
 ifneq ($(CONFIG_TLS), linux)
 ifneq ($(CONFIG_TLS), wolfssl)
 AESOBJS += ../src/crypto/aes-omac1.o
+endif
 endif
 endif
 ifdef NEED_AES_UNWRAP

--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -1253,6 +1253,7 @@ int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 	ret = 0;
 fail:
 	EVP_MAC_CTX_free(ctx);
+	EVP_MAC_free(emac);
 	return ret;
 #else /* OpenSSL version >= 3.0 */
 	CMAC_CTX *ctx;

--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -16,10 +16,9 @@
 #include <openssl/dh.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-#else /* OpenSSL version >= 3.0 */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 #include <openssl/cmac.h>
-#endif /* OpenSSL version >= 3.0 */
+#endif /* OpenSSL version < 3.0 */
 #ifdef CONFIG_ECC
 #include <openssl/ec.h>
 #include <openssl/x509.h>

--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -1214,7 +1214,6 @@ int crypto_get_random(void *buf, size_t len)
 }
 
 
-#ifdef CONFIG_OPENSSL_CMAC
 int omac1_aes_vector(const u8 *key, size_t key_len, size_t num_elem,
 		     const u8 *addr[], const size_t *len, u8 *mac)
 {
@@ -1308,7 +1307,6 @@ int omac1_aes_256(const u8 *key, const u8 *data, size_t data_len, u8 *mac)
 {
 	return omac1_aes_vector(key, 32, 1, &data, &data_len, mac);
 }
-#endif /* CONFIG_OPENSSL_CMAC */
 
 
 struct crypto_bignum * crypto_bignum_init(void)

--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -16,9 +16,10 @@
 #include <openssl/dh.h>
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
-#ifdef CONFIG_OPENSSL_CMAC
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#else /* OpenSSL version >= 3.0 */
 #include <openssl/cmac.h>
-#endif /* CONFIG_OPENSSL_CMAC */
+#endif /* OpenSSL version >= 3.0 */
 #ifdef CONFIG_ECC
 #include <openssl/ec.h>
 #include <openssl/x509.h>

--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -75,7 +75,6 @@ endif
 
 ifdef CONFIG_FIPS
 CONFIG_NO_RANDOM_POOL=
-CONFIG_OPENSSL_CMAC=y
 endif
 
 OBJS = config.o

--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -1330,9 +1330,7 @@ ifdef NEED_AES_ENCBLOCK
 AESOBJS += ../src/crypto/aes-encblock.o
 endif
 NEED_AES_ENC=y
-ifdef CONFIG_OPENSSL_CMAC
-CFLAGS += -DCONFIG_OPENSSL_CMAC
-else
+ifneq ($(CONFIG_TLS), openssl)
 ifneq ($(CONFIG_TLS), linux)
 ifneq ($(CONFIG_TLS), wolfssl)
 AESOBJS += ../src/crypto/aes-omac1.o


### PR DESCRIPTION
Wpa_supplicant OpenSSL CMAC wrapper API (omac1_aes_vector) is only available when FIPs is enabled for build. Which should not be the case. Openssl CMAC wrapper API should also be available under non FIPS mode. When wpa-supplicant is referencing to use openssl,  openssl CMAC should be triggered instead of wpa internal one.

The fix is mostly taking from hostap with those changes already:
https://w1.fi/cgit/hostap/commit/src/crypto?id=ae0f6ee97ed4924189f2cd68548d2a971f17d67e https://w1.fi/cgit/hostap/commit/wpa_supplicant/Makefile?id=ae0f6ee97ed4924189f2cd68548d2a971f17d67e

Testing has been done with the changes with FIPS and non FIPS mode by running sonic macsec testing suite. It's observed in all scenario openssl CMAC API is triggered. 