### PR TITLE
Enable CONFIG_FIPS for wpa_supplicant

### DIFF
--- a/debian/patches/001_enable_config_fips.patch
+++ b/debian/patches/001_enable_config_fips.patch
@@ -84,7 +84,11 @@ index ef872c50e..783e50b23 100644
  			static int fips_enabled = 0;
  
 -			if (!fips_enabled && !FIPS_mode_set(1)) {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 +			if (!fips_enabled && !EVP_default_properties_enable_fips(NULL, 1)) {
++#else
++			if (!fips_enabled && !FIPS_mode_set(1)) {
++#endif /* OpenSSL version >= 3.0 */
  				wpa_printf(MSG_ERROR, "Failed to enable FIPS "
  					   "mode");
  				ERR_load_crypto_strings();

--- a/debian/patches/001_enable_config_fips.patch
+++ b/debian/patches/001_enable_config_fips.patch
@@ -1,0 +1,114 @@
+diff --git a/src/crypto/crypto_openssl.c b/src/crypto/crypto_openssl.c
+index b644b6ca7..363b553fb 100644
+--- a/src/crypto/crypto_openssl.c
++++ b/src/crypto/crypto_openssl.c
+@@ -193,12 +193,16 @@ static int openssl_digest_vector(const EVP_MD *type, size_t num_elem,
+ }
+ 
+ 
+-#ifndef CONFIG_FIPS
+ int md4_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+ {
++#ifndef CONFIG_FIPS
+ 	return openssl_digest_vector(EVP_md4(), num_elem, addr, len, mac);
+-}
++#else 
++	wpa_printf(MSG_ERROR, "OpenSSL %s: md4 is not allowed in FIPS mode", __func__);
++	return -1;
+ #endif /* CONFIG_FIPS */
++}
++
+ 
+ 
+ int des_encrypt(const u8 *clear, const u8 *key, u8 *cypher)
+@@ -264,12 +268,15 @@ out:
+ #endif /* CONFIG_NO_RC4 */
+ 
+ 
+-#ifndef CONFIG_FIPS
+ int md5_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+ {
++#ifndef CONFIG_FIPS
+ 	return openssl_digest_vector(EVP_md5(), num_elem, addr, len, mac);
+-}
++#else 
++	wpa_printf(MSG_ERROR, "OpenSSL %s: md5 is not allowed in FIPS mode", __func__);
++	return -1;
+ #endif /* CONFIG_FIPS */
++}
+ 
+ 
+ int sha1_vector(size_t num_elem, const u8 *addr[], const size_t *len, u8 *mac)
+@@ -1105,13 +1112,16 @@ done:
+ }
+ 
+ 
+-#ifndef CONFIG_FIPS
+-
+ int hmac_md5_vector(const u8 *key, size_t key_len, size_t num_elem,
+ 		    const u8 *addr[], const size_t *len, u8 *mac)
+ {
++#ifndef CONFIG_FIPS
+ 	return openssl_hmac_vector(EVP_md5(), key ,key_len, num_elem, addr, len,
+ 				   mac, 16);
++#else
++	wpa_printf(MSG_ERROR, "OpenSSL %s: md5 is not allowed in FIPS mode", __func__);
++	return -1;
++#endif /* CONFIG_FIPS */
+ }
+ 
+ 
+@@ -1121,8 +1131,6 @@ int hmac_md5(const u8 *key, size_t key_len, const u8 *data, size_t data_len,
+ 	return hmac_md5_vector(key, key_len, 1, &data, &data_len, mac);
+ }
+ 
+-#endif /* CONFIG_FIPS */
+-
+ 
+ int pbkdf2_sha1(const char *passphrase, const u8 *ssid, size_t ssid_len,
+ 		int iterations, u8 *buf, size_t buflen)
+diff --git a/src/crypto/tls_openssl.c b/src/crypto/tls_openssl.c
+index ef872c50e..783e50b23 100644
+--- a/src/crypto/tls_openssl.c
++++ b/src/crypto/tls_openssl.c
+@@ -21,6 +21,7 @@
+ #include <openssl/opensslv.h>
+ #include <openssl/pkcs12.h>
+ #include <openssl/x509v3.h>
++#include <openssl/evp.h>
+ #ifndef OPENSSL_NO_ENGINE
+ #include <openssl/engine.h>
+ #endif /* OPENSSL_NO_ENGINE */
+@@ -965,7 +966,7 @@ void * tls_init(const struct tls_config *conf)
+ 		if (conf && conf->fips_mode) {
+ 			static int fips_enabled = 0;
+ 
+-			if (!fips_enabled && !FIPS_mode_set(1)) {
++			if (!fips_enabled && !EVP_default_properties_enable_fips(NULL, 1)) {
+ 				wpa_printf(MSG_ERROR, "Failed to enable FIPS "
+ 					   "mode");
+ 				ERR_load_crypto_strings();
+diff --git a/wpa_supplicant/Makefile b/wpa_supplicant/Makefile
+index 6e50c808b..049e04347 100644
+--- a/wpa_supplicant/Makefile
++++ b/wpa_supplicant/Makefile
+@@ -4,6 +4,10 @@ ifndef CONFIG_NO_WPA_PASSPHRASE
+ BINALL += wpa_passphrase
+ endif
+ 
++ifndef CONFIG_FIPS
++CONFIG_FIPS=y
++endif
++
+ ALL = $(BINALL)
+ ALL += systemd/wpa_supplicant.service
+ ALL += systemd/wpa_supplicant@.service
+@@ -1682,7 +1686,7 @@ CFLAGS += -DCONFIG_DELAYED_MIC_ERROR_REPORT
+ endif
+ 
+ ifdef CONFIG_FIPS
+-CFLAGS += -DCONFIG_FIPS
++CFLAGS += -DCONFIG_FIPS -DOPENSSL_FIPS
+ ifneq ($(CONFIG_TLS), openssl)
+ ifneq ($(CONFIG_TLS), wolfssl)
+ $(error CONFIG_FIPS=y requires CONFIG_TLS=openssl)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+001_enable_config_fips.patch

--- a/src/crypto/tls_openssl.c
+++ b/src/crypto/tls_openssl.c
@@ -964,8 +964,11 @@ void * tls_init(const struct tls_config *conf)
 #ifdef OPENSSL_FIPS
 		if (conf && conf->fips_mode) {
 			static int fips_enabled = 0;
-
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+			if (!fips_enabled && !EVP_default_properties_enable_fips(NULL, 1)) {
+#else
 			if (!fips_enabled && !FIPS_mode_set(1)) {
+#endif /* OpenSSL version >= 3.0 */
 				wpa_printf(MSG_ERROR, "Failed to enable FIPS "
 					   "mode");
 				ERR_load_crypto_strings();

--- a/src/crypto/tls_openssl.c
+++ b/src/crypto/tls_openssl.c
@@ -964,11 +964,8 @@ void * tls_init(const struct tls_config *conf)
 #ifdef OPENSSL_FIPS
 		if (conf && conf->fips_mode) {
 			static int fips_enabled = 0;
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-			if (!fips_enabled && !EVP_default_properties_enable_fips(NULL, 1)) {
-#else
+
 			if (!fips_enabled && !FIPS_mode_set(1)) {
-#endif /* OpenSSL version >= 3.0 */
 				wpa_printf(MSG_ERROR, "Failed to enable FIPS "
 					   "mode");
 				ERR_load_crypto_strings();


### PR DESCRIPTION
**Issues:**
Wpa_supplicant has support to enable FIPS for wpa_supplicant by setting CONFIG_FIPS. This will limit the usage of certain insecure algorithms such as MD4, MD5, DES, RC4. This is one of the requirements by FIPS 140-3. 

It's found that wpa_supplicant does not support this config (CONFIG_FIPS=y) nicely. After turning on this flag, it's found that the make would not succeed. There are 2 issues which are fixed by this PR:

1) There are still references in wpa_supplicant for those insured crypto APIs such as md4_vector etc. Macsec is not using any of those APIs though. Wpa_supplicant disables those APIs from crypt_openssl.c when CONFIG_FIPS is enabled. Fixed those issues by leaving the corresponding API definitions (such as md4_vector etc) there but logging an error message and returning error (-1) when CONFIG_FIPS is enabled.

2) FIPS_mode_set(1) is removed from openssl 3.0.0. Solution is to replace with EVP_default_properties_enable_fips(NULL, 1) as Openssl forum suggests.

This PR uses patch with above changes. This will benefit us for later porting of latest wpa_supplicant.

**Testing:** 
Tested above changes on VM environment with macsec testing suites. With FIPS enable and FIPS disable, all macsec testings passed. 
Watched wpa_supplicant build log and found patch has been applied during build with no issues.